### PR TITLE
moved geometry NativeQueries in model classes

### DIFF
--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueDao.java
@@ -31,7 +31,7 @@ import de.btu.openinfra.backend.db.pojos.ValueListValuePojo;
  * @author <a href="http://www.b-tu.de">BTU</a> DBIS
  *
  */
-public class AttributeValueDao extends 
+public class AttributeValueDao extends
     OpenInfraValueValueDao<AttributeValuePojo,
 	    AttributeValue, TopicInstance, AttributeType> {
 
@@ -42,15 +42,6 @@ public class AttributeValueDao extends
 	// TODO: add a static parameter or make it dynamically
 	private AttributeValueGeomType defaultGeomType =
 			AttributeValueGeomType.TEXT;
-
-	/**
-	 * This variable defines the SQL string which is used to retrieve the
-	 * requested geometry type string from database.
-	 */
-	public static final String GEOM_CLAUSE =
-			"select %s "
-			+ "from attribute_value_geom%s "
-			+ "where id = cast(? as uuid)";
 
 	/**
 	 * This is the required constructor which calls the super constructor and in

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueGeomDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueGeomDao.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 
 import javax.persistence.Query;
 
+import org.eclipse.persistence.jpa.JpaQuery;
+
 import de.btu.openinfra.backend.db.jpa.model.AttributeTypeToAttributeTypeGroup;
 import de.btu.openinfra.backend.db.jpa.model.AttributeValueGeom;
 import de.btu.openinfra.backend.db.jpa.model.TopicInstance;
@@ -71,11 +73,14 @@ public class AttributeValueGeomDao
 	public AttributeValueGeomPojo mapToPojo(
 			Locale locale,
 			AttributeValueGeom avg) {
+	    // get the NamedNativeQuery
+        String sqlString = em.createNamedQuery(
+                AttributeValueGeom.class.getSimpleName() + ".select")
+                .unwrap(JpaQuery.class).getDatabaseQuery().getSQLString();
 	    // format the SQL statement for retrieving geometry values
 		String queryString = String.format(
-				AttributeValueDao.GEOM_CLAUSE,
-				defaultGeomType.getPsqlFnSignature(),
-				"");
+		        sqlString,
+				defaultGeomType.getPsqlFnSignature());
 
         // add the id parameter to the query
         Query qGeom = em.createNativeQuery(queryString);

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueGeomzDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/AttributeValueGeomzDao.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 
 import javax.persistence.Query;
 
+import org.eclipse.persistence.jpa.JpaQuery;
+
 import de.btu.openinfra.backend.db.jpa.model.AttributeTypeToAttributeTypeGroup;
 import de.btu.openinfra.backend.db.jpa.model.AttributeValueGeomz;
 import de.btu.openinfra.backend.db.jpa.model.TopicInstance;
@@ -74,11 +76,14 @@ public class AttributeValueGeomzDao
 	public AttributeValueGeomzPojo mapToPojo(
 			Locale locale,
 			AttributeValueGeomz avgz) {
-	    // format the SQL statement for retrieving geometry values
-	    String queryString = String.format(
-                AttributeValueDao.GEOM_CLAUSE,
-                defaultGeomType.getPsqlFnSignature(),
-                "z");
+	    // get the NamedNativeQuery
+        String sqlString = em.createNamedQuery(
+                AttributeValueGeomz.class.getSimpleName() + ".select")
+                .unwrap(JpaQuery.class).getDatabaseQuery().getSQLString();
+        // format the SQL statement for retrieving geometry values
+        String queryString = String.format(
+                sqlString,
+                defaultGeomType.getPsqlFnSignature());
 
 	    // add the id parameter to the query
 	    Query qGeom = em.createNativeQuery(queryString);

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/OpenInfraDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/OpenInfraDao.java
@@ -60,26 +60,6 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
 	protected OpenInfraSchemas schema;
 
 	/**
-     * This variable defines the SQL string which is used to insert a new
-     * geometry value into the database.
-     */
-    private static final String GEOM_INSERT_CLAUSE = ""
-            + "INSERT INTO attribute_value_geom%s ("
-            + "attribute_type_to_attribute_type_group_id, "
-            + "topic_instance_id, geom) "
-            + "VALUES (?, ?, %s(?))";
-
-    /**
-     * This variable defines the SQL string which is used to update an existing
-     * geometry value in the database.
-     */
-    private static final String GEOM_UPDATE_CLAUSE = ""
-            + "UPDATE TABLE attribute_value_geom%s SET "
-            + "attribute_type_to_attribute_type_group_id = ?, "
-            + "topic_instance_id = ?, "
-            + "geom = %s(?) WHERE id = ?";
-
-	/**
 	 * This method represents the super constructor in order to create an entity
 	 * manager for each data access object (DAO) in a sophisticated way. We
 	 * decided to use an application managed entity manager in order to have
@@ -331,8 +311,8 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
 		try {
 			et.begin();
 			// special handling for geometry classes
-			if (modelClass.getSimpleName() == "AttributeValueGeom" ||
-			        modelClass.getSimpleName() == "AttributeValueGeomz") {
+			if (modelClass.getSimpleName().equals("AttributeValueGeom") ||
+			        modelClass.getSimpleName().equals("AttributeValueGeomz")) {
                 Query geomQuery = createGeomQuery(pojo);
                 if (geomQuery != null) {
                     // execute the query
@@ -368,10 +348,14 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
         // create the special query for AttributeValueGeomz
         case "AttributeValueGeomz":
             if (pojo.getUuid() == null) {
+                // get the NamedNativeQuery
+                String sqlString = em.createNamedQuery(
+                        modelClass.getSimpleName() + ".insert")
+                        .unwrap(JpaQuery.class).getDatabaseQuery()
+                        .getSQLString();
                 // format the prepared INSERT statement
                 String queryString = String.format(
-                        GEOM_INSERT_CLAUSE,
-                        "z",
+                        sqlString,
                         // set the PostGIS function for the geomType
                         AttributeValueGeomWriteType.valueOf(
                                 ((AttributeValueGeomzPojo) pojo)
@@ -381,11 +365,15 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
             } else {
                 // TODO: JPA replaces the native query with its own query that
                 // leads to a type error: varchar / geometry
-                // format the prepared UPDATE statement
                 /*
+                // get the NamedNativeQuery
+                String sqlString = em.createNamedQuery(
+                        modelClass.getSimpleName() + ".insert")
+                        .unwrap(JpaQuery.class).getDatabaseQuery()
+                        .getSQLString();
+                // format the prepared UPDATE statement
                 String queryString = String.format(
-                        GEOM_UPDATE_CLAUSE,
-                        "z",
+                        sqlString,
                         // set the PostGIS function for the geomType
                         AttributeValueGeomWriteType.valueOf(
                                 ((AttributeValueGeomzPojo) pojo)
@@ -410,10 +398,14 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
             break;
         case "AttributeValueGeom":
             if (pojo.getUuid() == null) {
+             // get the NamedNativeQuery
+                String sqlString = em.createNamedQuery(
+                        modelClass.getSimpleName() + ".insert")
+                        .unwrap(JpaQuery.class).getDatabaseQuery()
+                        .getSQLString();
                 // format the prepared INSERT statement
                 String queryString = String.format(
-                        GEOM_INSERT_CLAUSE,
-                        "",
+                        sqlString,
                         // set the PostGIS function for the geomType
                         AttributeValueGeomWriteType.valueOf(
                                 ((AttributeValueGeomPojo) pojo)
@@ -424,10 +416,14 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
                 // TODO: JPA replaces the native query with its own query that
                 // leads to a type error: varchar / geometry
                 /*
+                // get the NamedNativeQuery
+                String sqlString = em.createNamedQuery(
+                        modelClass.getSimpleName() + ".insert")
+                        .unwrap(JpaQuery.class).getDatabaseQuery()
+                        .getSQLString();
                 // format the prepared UPDATE statement
                 String queryString = String.format(
-                        GEOM_UPDATE_CLAUSE,
-                        "",
+                        sqlString
                         // set the PostGIS function for the geomType
                         AttributeValueGeomWriteType.valueOf(
                                 ((AttributeValueGeomPojo) pojo)

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueGeom.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueGeom.java
@@ -7,17 +7,36 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 
 /**
  * The persistent class for the attribute_value_geom database table.
- * 
+ *
  */
 @Entity
 @Table(name="attribute_value_geom")
-@NamedQuery(name="AttributeValueGeom.findAll", query="SELECT a FROM AttributeValueGeom a")
+@NamedQuery(name="AttributeValueGeom.findAll",
+    query="SELECT a FROM AttributeValueGeom a")
+@NamedNativeQueries({
+    @NamedNativeQuery(name="AttributeValueGeom.select",
+            query="SELECT %s "
+                    + "FROM attribute_value_geom "
+                    + "WHERE id = cast(? as uuid)"),
+    @NamedNativeQuery(name="AttributeValueGeom.insert",
+            query="INSERT INTO attribute_value_geom ("
+                    + "attribute_type_to_attribute_type_group_id, "
+                    + "topic_instance_id, geom) "
+                    + "VALUES (?, ?, %s(?))"),
+    @NamedNativeQuery(name="AttributeValueGeom.update",
+            query="UPDATE TABLE attribute_value_geom SET "
+                    + "attribute_type_to_attribute_type_group_id = ?, "
+                    + "topic_instance_id = ?, "
+                    + "geom = %s(?) WHERE id = ?")
+})
 public class AttributeValueGeom implements Serializable, OpenInfraModelObject {
 	private static final long serialVersionUID = 1L;
 
@@ -39,7 +58,8 @@ public class AttributeValueGeom implements Serializable, OpenInfraModelObject {
 	public AttributeValueGeom() {
 	}
 
-	public UUID getId() {
+	@Override
+    public UUID getId() {
 		return this.id;
 	}
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueGeomz.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueGeomz.java
@@ -7,6 +7,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -14,7 +16,7 @@ import javax.persistence.Table;
 
 /**
  * The persistent class for the attribute_value_geomz database table.
- * 
+ *
  */
 @Entity
 @Table(name="attribute_value_geomz")
@@ -23,7 +25,24 @@ import javax.persistence.Table;
             query="SELECT a FROM AttributeValueGeomz a"),
     @NamedQuery(name="AttributeValueGeomz.findByTopicInstance",
             query="SELECT a "
-                    + "FROM AttributeValueGeomz a WHERE a.topicInstance = :value")})
+                    + "FROM AttributeValueGeomz a "
+                    + "WHERE a.topicInstance = :value")})
+@NamedNativeQueries({
+    @NamedNativeQuery(name="AttributeValueGeomz.select",
+            query="SELECT %s "
+                    + "FROM attribute_value_geomz "
+                    + "WHERE id = cast(? as uuid)"),
+    @NamedNativeQuery(name="AttributeValueGeomz.insert",
+            query="INSERT INTO attribute_value_geomz ("
+                    + "attribute_type_to_attribute_type_group_id, "
+                    + "topic_instance_id, geom) "
+                    + "VALUES (?, ?, %s(?))"),
+    @NamedNativeQuery(name="AttributeValueGeomz.update",
+            query="UPDATE TABLE attribute_value_geomz SET "
+                    + "attribute_type_to_attribute_type_group_id = ?, "
+                    + "topic_instance_id = ?, "
+                    + "geom = %s(?) WHERE id = ?")
+})
 
 public class AttributeValueGeomz implements Serializable, OpenInfraModelObject {
 	private static final long serialVersionUID = 1L;
@@ -46,7 +65,8 @@ public class AttributeValueGeomz implements Serializable, OpenInfraModelObject {
 	public AttributeValueGeomz() {
 	}
 
-	public UUID getId() {
+	@Override
+    public UUID getId() {
 		return this.id;
 	}
 


### PR DESCRIPTION
For accessing and writing geometry data special NativeQueries are
necessary. These queries moved into the model classes as real
NativeQueries.
