### PR TITLE
added entity synchronization for new created objects

### DIFF
--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/OpenInfraDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/OpenInfraDao.java
@@ -252,6 +252,13 @@ public abstract class OpenInfraDao<TypePojo extends OpenInfraPojo,
 			et.begin();
 	        em.merge(result.getModelObject());
 			et.commit();
+
+			// This will force a synchronization of the current created entity.
+			// Necessary for retrieving the xmin value for newly created
+			// entities.
+			// TODO avoid refresh for updated objects
+            em.refresh(em.find(modelClass, result.getId()));
+
 			return result.getId();
 		} catch(RuntimeException ex) {
 			if(et != null && et.isActive()) {

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValue.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValue.java
@@ -13,12 +13,12 @@ import javax.persistence.Table;
 
 /**
  * The persistent class for the attribute_value database table.
- * 
+ *
  */
 @Entity
 @Table(name="attribute_value")
 @NamedQueries({
-	@NamedQuery(name="AttributeValue.findAll", 
+	@NamedQuery(name="AttributeValue.findAll",
 			query="SELECT a FROM AttributeValue a"),
 	@NamedQuery(name="AttributeValue.findByTopicInstance",
 			query="SELECT a "
@@ -41,7 +41,7 @@ public class AttributeValue extends OpenInfraModelObject
 	private AttributeTypeToAttributeTypeGroup attributeTypeToAttributeTypeGroup;
 
 	//bi-directional many-to-one association to TopicInstance
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="topic_instance_id")
 	private TopicInstance topicInstance;
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueValue.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/AttributeValueValue.java
@@ -12,7 +12,7 @@ import javax.persistence.Table;
 
 /**
  * The persistent class for the attribute_value_value database table.
- * 
+ *
  */
 @Entity
 @Table(name="attribute_value_value")
@@ -27,7 +27,7 @@ public class AttributeValueValue extends OpenInfraModelObject
 	private AttributeTypeToAttributeTypeGroup attributeTypeToAttributeTypeGroup;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="value")
 	private PtFreeText ptFreeText;
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/Project.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/Project.java
@@ -13,7 +13,7 @@ import javax.persistence.OneToMany;
 
 /**
  * The persistent class for the project database table.
- * 
+ *
  */
 @Entity
 @NamedQuery(name="Project.findAll", query="SELECT p FROM Project p")
@@ -30,12 +30,12 @@ public class Project extends OpenInfraModelObject implements Serializable {
 	private List<Project> projects;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="description")
 	private PtFreeText ptFreeText1;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="name")
 	private PtFreeText ptFreeText2;
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/PtFreeText.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/PtFreeText.java
@@ -12,7 +12,7 @@ import javax.persistence.Table;
 
 /**
  * The persistent class for the pt_free_text database table.
- * 
+ *
  */
 @Entity
 @Table(name="pt_free_text")
@@ -41,7 +41,8 @@ public class PtFreeText extends OpenInfraModelObject implements Serializable {
 	private List<AttributeValueValue> attributeValueValues;
 
 	//bi-directional many-to-one association to LocalizedCharacterString
-	@OneToMany(mappedBy="ptFreeText", cascade=CascadeType.MERGE)
+	@OneToMany(mappedBy="ptFreeText",
+	           cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	private List<LocalizedCharacterString> localizedCharacterStrings;
 
 	//bi-directional many-to-one association to Project

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/TopicInstance.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/TopicInstance.java
@@ -128,7 +128,8 @@ public class TopicInstance extends OpenInfraModelObject
 	private List<AttributeValueGeomz> attributeValueGeomzs;
 
 	//bi-directional many-to-one association to AttributeValueValue
-	@OneToMany(mappedBy="topicInstance", cascade=CascadeType.MERGE)
+	@OneToMany(mappedBy="topicInstance",
+	           cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	private List<AttributeValueValue> attributeValueValues;
 
 	//bi-directional many-to-one association to TopicCharacteristic

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/ValueList.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/ValueList.java
@@ -30,7 +30,7 @@ import javax.persistence.Table;
 @NamedNativeQueries({
 	@NamedNativeQuery(name="ValueList.findAllByLocaleAndOrder",
 			query="select * "
-				  + "from value_list as vl " 
+				  + "from value_list as vl "
 			      + "LEFT OUTER JOIN ( "
 			      	+ "select * "
 			      	+ "from value_list as a, localized_character_string as b "
@@ -48,12 +48,12 @@ public class ValueList extends OpenInfraModelObject implements Serializable {
 	private List<AttributeType> attributeTypes;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="description")
 	private PtFreeText ptFreeText1;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="name")
 	private PtFreeText ptFreeText2;
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/ValueListValue.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/ValueListValue.java
@@ -70,12 +70,12 @@ public class ValueListValue extends OpenInfraModelObject
 	private List<TopicCharacteristic> topicCharacteristics;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="description")
 	private PtFreeText ptFreeText1;
 
 	//bi-directional many-to-one association to PtFreeText
-	@ManyToOne(cascade=CascadeType.MERGE)
+	@ManyToOne(cascade={CascadeType.MERGE,CascadeType.REFRESH})
 	@JoinColumn(name="name")
 	private PtFreeText ptFreeText2;
 


### PR DESCRIPTION
Adding the system column xmin to our POJOs created a problem when
creating a new object. If we create a new object the entity in the JPA
cache will not include the xmin value because this will be created by
PostgreSQL on the database. So if we created a new object and tried to
read this newly created object we received a NullPointerException while
reading xmin. This problem was solved by adding a em.refresh() on the
currently created object. Additionally the cascade type of several model
classes was updated to do a cascading refresh.
