### PR TITLE
updated projects table in meta data schema

### DIFF
--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/MetaDataManager.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/MetaDataManager.java
@@ -9,35 +9,40 @@ import de.btu.openinfra.backend.db.jpa.model.meta.Projects;
 import de.btu.openinfra.backend.db.pojos.meta.ProjectsPojo;
 
 /**
- * This class implements access to the meta database using a singleton 
- * implementation.  
- * 
+ * This class implements access to the meta database using a singleton
+ * implementation.
+ *
  * @author <a href="http://www.b-tu.de">BTU</a> DBIS
  *
  */
 public class MetaDataManager {
-	
+
 	/**
 	 * The entity manager used for accessing the meta database.
 	 */
 	private static EntityManager emMeta;
-	
+
 	/**
 	 * This method retrieves the connection string and credentials required for
 	 * accessing the current project. The current project id is set by the
 	 * constructor method.
-	 * 
+	 *
 	 * @return The connection string and credentials required to access the
 	 *         current project.
 	 */
-	public static ProjectsPojo getProjects(UUID projectId) {	
+	public static ProjectsPojo getProjects(UUID projectId) {
 		if(emMeta == null) {
 			emMeta = EntityManagerFactoryCache.getEntityManagerFactory(
 			        projectId,
 			        OpenInfraSchemas.META_DATA).createEntityManager();
 		}
-		
-		Projects p = emMeta.find(Projects.class, projectId);
+
+		// retrieve the project from the meta data
+		Projects p = emMeta.createNamedQuery(
+              "Projects.findByProject",
+              Projects.class)
+              .setParameter("value", projectId)
+              .getSingleResult();
 		return ProjectsDao.mapPojoStatically(p);
 	}
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/ProjectDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/ProjectDao.java
@@ -87,12 +87,12 @@ public class ProjectDao extends OpenInfraDao<ProjectPojo, Project> {
 	 */
 	public List<ProjectPojo> readMainProjects(Locale locale) {
 		// 1. We need to deliver each main Project from meta data database
-		List<ProjectsPojo> projects = new ProjectsDao(
+		List<ProjectsPojo> metaProjects = new ProjectsDao(
 				OpenInfraSchemas.META_DATA).read(
 						locale,
 						0,
 						Integer.MAX_VALUE);
-		Iterator<ProjectsPojo> it = projects.iterator();
+		Iterator<ProjectsPojo> it = metaProjects.iterator();
 		// 2. Only keep main projects in the list
 		while (it.hasNext()) {
 			if(it.next().getIsSubproject()) {
@@ -102,10 +102,11 @@ public class ProjectDao extends OpenInfraDao<ProjectPojo, Project> {
 		// 3. Create a list of main projects and add a corresponding main
 		//    project to the list found in the metadata database
 		List<ProjectPojo> mainProjects = new LinkedList<ProjectPojo>();
-		for(ProjectsPojo item : projects) {
+		for(ProjectsPojo item : metaProjects) {
 			ProjectPojo pp = new ProjectDao(
-					 item.getUuid(),
-					 OpenInfraSchemas.PROJECTS).read(locale, item.getUuid());
+					 item.getProjectId(),
+					 OpenInfraSchemas.PROJECTS).read(
+					         locale, item.getProjectId());
 			if(pp != null) {
 				mainProjects.add(pp);
 			}
@@ -264,10 +265,10 @@ public class ProjectDao extends OpenInfraDao<ProjectPojo, Project> {
 	 *                went wrong
 	 */
 	public static UUID createProject(ProjectPojo project) {
-		
+
 		System.out.println("This method (ProjectDao - createProject) is "
 				+ "currently not secured!!!!!!!!!");
-		
+
 	    UUID id = null;
 
 	    // determine if we want to create a sub or a main project

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/meta/ProjectsDao.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/daos/meta/ProjectsDao.java
@@ -42,6 +42,7 @@ public class ProjectsDao
     public static ProjectsPojo mapPojoStatically(Projects p) {
         if (p != null) {
             ProjectsPojo pojo = new ProjectsPojo(p);
+            pojo.setProjectId(p.getProjectId());
             pojo.setDatabaseConnection(
                     DatabaseConnectionDao.mapPojoStatically(
                             p.getDatabaseConnection()));
@@ -79,6 +80,7 @@ public class ProjectsDao
                 resultProjects = new Projects();
                 resultProjects.setId(pojo.getUuid());
             }
+            resultProjects.setProjectId(pojo.getProjectId());
             resultProjects.setIsSubproject(pojo.getIsSubproject());
             resultProjects.setDatabaseConnection(
                     DatabaseConnectionDao.mapToModelStatically(

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/meta/Projects.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/jpa/model/meta/Projects.java
@@ -2,6 +2,7 @@ package de.btu.openinfra.backend.db.jpa.model.meta;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,14 +18,16 @@ import de.btu.openinfra.backend.db.jpa.model.OpenInfraModelObject;
 
 /**
  * The persistent class for the projects database table.
- * 
+ *
  */
 @Entity
 @Table(schema="meta_data")
 @NamedQueries({
 	@NamedQuery(name="Projects.findAll", query="SELECT p FROM Projects p"),
     @NamedQuery(name="Projects.count",
-    	query="SELECT COUNT(p) FROM Projects p")
+    	query="SELECT COUNT(p) FROM Projects p"),
+	@NamedQuery(name="Projects.findByProject",
+	    query="SELECT p FROM Projects p WHERE p.projectId = :value")
 })
 public class Projects extends OpenInfraModelObject implements Serializable {
 	private static final long serialVersionUID = 1L;
@@ -32,11 +35,14 @@ public class Projects extends OpenInfraModelObject implements Serializable {
 	@Column(name="is_subproject")
 	private Boolean isSubproject;
 
+	@Column(name="project_id")
+	private UUID projectId;
+
 	//bi-directional many-to-one association to DatabaseConnection
 	@ManyToOne
 	@JoinColumn(name="database_connection_id")
 	private DatabaseConnection databaseConnection;
-	
+
 	//bi-directional many-to-one association to Projects
     @OneToMany(mappedBy="project")
     private List<Settings> settings;
@@ -51,6 +57,14 @@ public class Projects extends OpenInfraModelObject implements Serializable {
 	public void setIsSubproject(Boolean isSubproject) {
 		this.isSubproject = isSubproject;
 	}
+
+	public UUID getProjectId() {
+        return this.projectId;
+    }
+
+    public void setProjectId(UUID projectId) {
+        this.projectId = projectId;
+    }
 
 	public DatabaseConnection getDatabaseConnection() {
 		return this.databaseConnection;
@@ -67,7 +81,7 @@ public class Projects extends OpenInfraModelObject implements Serializable {
     public void setSettings(List<Settings> settings) {
         this.settings = settings;
     }
-    
+
     public Settings addSetting(Settings setting) {
         getSettings().add(setting);
         setting.setProject(this);

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/pojos/meta/ProjectsPojo.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/pojos/meta/ProjectsPojo.java
@@ -1,5 +1,7 @@
 package de.btu.openinfra.backend.db.pojos.meta;
 
+import java.util.UUID;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 import de.btu.openinfra.backend.db.jpa.model.OpenInfraModelObject;
@@ -9,6 +11,7 @@ import de.btu.openinfra.backend.db.pojos.OpenInfraPojo;
 public class ProjectsPojo extends OpenInfraPojo {
 
     private boolean isSubproject;
+    private UUID projectId;
     private DatabaseConnectionPojo databaseConnection;
 
     /* Default constructor */
@@ -25,6 +28,14 @@ public class ProjectsPojo extends OpenInfraPojo {
 
     public void setIsSubproject(boolean isSubproject) {
         this.isSubproject = isSubproject;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(UUID projectId) {
+        this.projectId = projectId;
     }
 
     public DatabaseConnectionPojo getDatabaseConnection() {


### PR DESCRIPTION
The projects table in the meta data schema was extended by an
independent primary key. Previously the primary key was the project id.
Due to this fact the backend must react to the new placed project id.
