### PR TITLE
updated project creation

### DIFF
--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/db/rbac/ProjectRbac.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/db/rbac/ProjectRbac.java
@@ -75,12 +75,13 @@ public class ProjectRbac extends
 	public UUID createProject(
 			ProjectPojo project,
 			boolean createEmpty,
+			boolean loadIntitialData,
 			OpenInfraHttpMethod httpMethod,
 			UriInfo uriInfo) {
 		checkPermission(httpMethod, uriInfo);
 		return new ProjectDao(
 		        null, OpenInfraSchemas.SYSTEM).createProject(
-		        		project, createEmpty);
+		        		project, createEmpty, loadIntitialData);
 	}
 
 	public boolean deleteProject(

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/exception/OpenInfraExceptionTypes.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/exception/OpenInfraExceptionTypes.java
@@ -15,6 +15,8 @@ public enum OpenInfraExceptionTypes {
 
     RENAME_SCHEMA("Failed to rename the project schema."),
 
+    INSERT_INITIAL_DATA("Failed to load the static value lists."),
+
     INSERT_META_DATA("Failed to create an entry in the table "
     		+ "database_connection."),
 

--- a/openinfra_core/src/main/java/de/btu/openinfra/backend/rest/project/ProjectResource.java
+++ b/openinfra_core/src/main/java/de/btu/openinfra/backend/rest/project/ProjectResource.java
@@ -168,15 +168,17 @@ public class ProjectResource {
 			@Context UriInfo uriInfo,
 			@Context HttpServletRequest request,
 			@QueryParam("createEmpty") boolean createEmpty,
+			@QueryParam("loadIntitialData") boolean loadIntitialData,
 			ProjectPojo project) {
 	    // create the project
-		System.out.println("--> " + createEmpty);
 		UUID id = new ProjectRbac(
 		        null, OpenInfraSchemas.PROJECTS).createProject(
 		                project,
 		                createEmpty,
+		                loadIntitialData,
 		                OpenInfraHttpMethod.valueOf(
 		                        request.getMethod()), uriInfo);
+
 		// TODO add informations to the meta data schema, this is necessary for
 		//      every REST end point this project should use
 		return OpenInfraResponseBuilder.postResponse(id);

--- a/openinfra_core/src/main/resources/META-INF/persistence.xml
+++ b/openinfra_core/src/main/resources/META-INF/persistence.xml
@@ -71,7 +71,7 @@
 		<class>de.btu.openinfra.backend.db.jpa.model.file.SupportedMimeType</class>
 	</persistence-unit>
 	
-	<!-- This PU is necessary to create new project schemas and fill them with some initial data -->
+	<!-- This PU is necessary to create new project schemas -->
 	<persistence-unit name="openinfra_schema_creation">
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>	
 		<properties>
@@ -79,9 +79,17 @@
 			<property name="javax.persistence.schema-generation.create-source" value="script" />
 			<property name="javax.persistence.schema-generation.create-script-source" 
 			          value="de/btu/openinfra/backend/sql/project_schema.sql" />
+		</properties>
+	</persistence-unit>
+	
+	<!-- This PU is necessary to fill the project schema with some initial data -->
+	<persistence-unit name="openinfra_static_valuelist_creation">
+		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>	
+		<properties>
+			<property name="javax.persistence.schema-generation.database.action" value="create" />
+			<property name="javax.persistence.schema-generation.create-source" value="script" />
 			<property name="javax.persistence.sql-load-script-source" 
 					  value="de/btu/openinfra/backend/sql/project_static_valuelist.sql"/>
 		</properties>
 	</persistence-unit>
-	
 </persistence>


### PR DESCRIPTION
Added two flags to configure the project creation. It is now possible to
create an empty project schema or to avoid merging the initial topic
framework from the system database.
